### PR TITLE
Expose celery configurations via environment variables.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,13 @@ COPY . /app
 # Copy the supervisord configuration file
 COPY configs/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# Set environment variables to configure Celery
+ENV CELERY_BROKER_DOMAIN=localhost
+ENV CELERY_BROKER_URL=pyamqp://guest@localhost:5672//
+ENV CELERY_RESULT_BACKEND=file:///app/celery_results
+ENV CELERY_WORKER_PREFETCH_MULTIPLIER=1
+ENV CELERY_TASK_ACKS_LATE=true
+
 # Make port 8080 available to the world outside this container
 EXPOSE 8080
 

--- a/src/task_manager/celery_tasks/__init__.py
+++ b/src/task_manager/celery_tasks/__init__.py
@@ -1,11 +1,25 @@
+import os
 import json
+import logging
 
 from celery import Celery
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def load_celery_config():
     with open('./configs/celery.json', 'r') as config_file:
         config = json.load(config_file)
+
+    config['broker_domain'] = os.getenv('CELERY_BROKER_DOMAIN', config['broker_domain'])
+    config['broker_url'] = os.getenv('CELERY_BROKER_URL', config['broker_url'])
+    config['result_backend'] = os.getenv('CELERY_RESULT_BACKEND', config['result_backend'])
+    config['worker_prefetch_multiplier'] = int(
+        os.getenv('CELERY_WORKER_PREFETCH_MULTIPLIER', config['worker_prefetch_multiplier']))
+    config['task_acks_late'] = os.getenv('CELERY_TASK_ACKS_LATE', str(config['task_acks_late']).lower()) in ['true',
+                                                                                                             '1', 't',
+                                                                                                             'y', 'yes']
     return config
 
 
@@ -14,6 +28,9 @@ def load_tasks_route():
         config = json.load(config_file)
     return config
 
+
+celery_config = load_celery_config()
+logger.warning("Celery Configuration: %s", json.dumps(celery_config, indent=4))
 
 celery_app = Celery(__name__, include=["src.task_manager.celery_tasks.tasks"])
 celery_app.conf.update(load_celery_config())


### PR DESCRIPTION
Expose following environment variable to configure celery task

```
ENV CELERY_BROKER_DOMAIN=localhost
ENV CELERY_BROKER_URL=pyamqp://guest@localhost:5672//
ENV CELERY_RESULT_BACKEND=file:///app/celery_results
ENV CELERY_WORKER_PREFETCH_MULTIPLIER=1
ENV CELERY_TASK_ACKS_LATE=true
```